### PR TITLE
[#100] RPM spec fixes

### DIFF
--- a/doc/RPM.md
+++ b/doc/RPM.md
@@ -2,34 +2,38 @@
 
 `hrmp` can be built into a RPM for [Fedora](https://getfedora.org/) systems.
 
-## Requirements
-
-```sh
-dnf install gcc rpm-build rpm-devel rpmlint make python bash coreutils diffutils patch rpmdevtools chrpath
-```
-
 ## Setup RPM development
 
 ```sh
+sudo dnf install rpmdevtools
 rpmdev-setuptree
 ```
 
-## Create source package
+## Get the source tree
 
 ```sh
 git clone https://github.com/HighResMusicPlayer/hrmp.git
 cd hrmp
-mkdir build
-cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
-make package_source
 ```
 
-## Create RPM package
+## Install build requirements
 
 ```sh
-cp hrmp-$VERSION.tar.gz ~/rpmbuild/SOURCES
-QA_RPATHS=0x0001 rpmbuild -bb hrmp.spec
+sudo dnf builddep hrmp.spec
 ```
 
-The resulting RPM will be located in `~/rpmbuild/RPMS/x86_64/`, if your architecture is `x86_64`.
+## Create the source archive
+
+```sh
+VERSION=0.14.0 # Should match one in hrmp.spec.
+TAG=HEAD # You can also use any real tag or sha.
+git archive --format=tar.gz --prefix=hrmp-$VERSION/ $TAG >~/rpmbuild/SOURCES/hrmp-$VERSION.tar.gz
+```
+
+## Create RPM packages
+
+```sh
+rpmbuild -ba hrmp.spec
+```
+
+The resulting RPMs will be located in `~/rpmbuild/RPMS/x86_64/`, if your architecture is `x86_64`.

--- a/hrmp.spec
+++ b/hrmp.spec
@@ -7,7 +7,7 @@ URL:           https://github.com/HighResMusicPlayer/hrmp
 Source0:       https://github.com/HighResMusicPlayer/hrmp/releases/download/%{version}/hrmp-%{version}.tar.gz
 
 BuildRequires: gcc cmake make python3-docutils alsa-lib alsa-lib-devel libsndfile libsndfile-devel opus-devel faad2-devel gtk3-devel ncurses-libs ncurses-devel
-Requires:      alsa-lib libsndfile opus faad2 gtk3 ncurses-labs
+Requires:      alsa-lib libsndfile opus faad2 gtk3 ncurses-libs
 
 %description
 hrmp is a high resolution music player.
@@ -19,7 +19,7 @@ hrmp is a high resolution music player.
 
 %{__mkdir} build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_RPATH=true ..
 %{__make}
 
 %install
@@ -32,6 +32,7 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 %{__mkdir} -p %{buildroot}%{_datadir}/applications
 %{__mkdir} -p %{buildroot}%{_datadir}/icons/hicolor
 %{__mkdir} -p %{buildroot}%{_sysconfdir}/hrmp
+%{__mkdir} -p %{buildroot}%{_docdir}/%{name}
 
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/LICENSE %{buildroot}%{_docdir}/%{name}/LICENSE
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/CODE_OF_CONDUCT.md %{buildroot}%{_docdir}/%{name}/CODE_OF_CONDUCT.md
@@ -59,8 +60,6 @@ for size in 16 24 32 48 64 96 128 256 512; do \
 done
 
 %{__install} -m 755 %{_builddir}/%{name}-%{version}/build/src/libhrmp.so.%{version} %{buildroot}%{_libdir}/libhrmp.so.%{version}
-
-chrpath -r %{_libdir} %{buildroot}%{_bindir}/hrmp
 
 cd %{buildroot}%{_libdir}/
 %{__ln_s} -f libhrmp.so.%{version} libhrmp.so.0


### PR DESCRIPTION
Bring the spec file to the working state:
    
1. Replace chrpath with cmake option -DCMAKE_SKIP_RPATH=true to fix
   all the check-rpaths warnings.
    
2. Fix a build failure caused by missing mkdir.
    
3. Fix a typo in ncurses-lib package name.
    
While at it, fix/simplify rpm build instructions in doc/RPM.md.
 
